### PR TITLE
Change dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
     "@babel/preset-flow": "^7.0.0-beta.40",
     "@babel/preset-react": "^7.0.0-beta.40",
     "flow-bin": "^0.66.0",
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
     "rollup": "^0.56.2",
     "rollup-plugin-babel": "^4.0.0-beta.0",
     "rollup-plugin-uglify": "^3.0.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^16.3.0",
     "react-dom": "^16.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@babel/preset-react": "^7.0.0-beta.40",
     "flow-bin": "^0.66.0",
     "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react-dom": "^16.3.0",
     "rollup": "^0.56.2",
     "rollup-plugin-babel": "^4.0.0-beta.0",
     "rollup-plugin-uglify": "^3.0.0"


### PR DESCRIPTION
removes dependencies, since you shouldn't depend on react-waterafll alone, but on react & react-waterfall together.
And more over, it will not warn about using react 16.2 with this library.