### PR TITLE
Adds check if Provider is initialized

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,14 @@ export const initStore: Function = (store, ...middlewares) => {
     // We do this so the sCU of Prevent will ignore the children prop
     _children = () => this.props.children
 
-    prevent = ({ state, actions }) => {
+    prevent = (args) => {
+      if (!args.state) {
+        err();
+
+        return null;
+      }
+
+      const { state, actions } = args;
       const { mapStateToProps } = this.props
       return (
         <Prevent {...mapStateToProps(state)} actions={actions} _children={this._children} />


### PR DESCRIPTION
If I use Consumer outside of a wrapping Provider atm, I get a non-helpful error like:

````
react-waterfall.js:1 Uncaught TypeError: Cannot read property 'state' of undefined
    at value (react-waterfall.js:1)
````

The proposed change checks for existance of the state-object and notifies otherwise. A possible point of debate could be the handling after the error. For now, it simply returns nothing...