### PR TITLE
Add support for observables utilizing observable bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ const prod = process.env.NODE_ENV === 'production'
 export const { Provider, connect } = initStore(store, !prod && devtools())
 ```
 
+## Observables
+
+You can speed up your performance (in case the map state to props function is costy)
+by providing an array of observable fields:
+
+```js
+const store = {
+  initialState: { count: 0, user: null },
+  actions: {
+    increment: ({ count }) => ({ count: count + 1 }),
+  },
+  observables: ['count']
+}
+```
+
+* It is an array of field names, straight under the state object
+* It doesn't have to be all the field in the state
+
+Then use it like:
+```js
+Count = connect(state => ({ count: state.count }), ['count'])(Count)
+```
+
+
 ## Types
 
 You can explore types [here](dist/react-waterfall.js.flow)


### PR DESCRIPTION
# DO NOT MERGE - only for discussion

Snippet from the `README.md` change:

----

## Observables

You can speed up your performance (in case the map state to props function is costy)
by providing an array of observable fields:

```js
const store = {
  initialState: { count: 0, user: null },
  actions: {
    increment: ({ count }) => ({ count: count + 1 }),
  },
  observables: ['count']
}
```

* It is an array of field names, straight under the state object
* It doesn't have to be all the field in the state

Then use it like:
```js
Count = connect(state => ({ count: state.count }), ['count'])(Count)
```
----
React's consumer will not re-render at all if the observed fields will not change, causing the mapStateToProps function not to evaluate.

The idea is that the `observables` array is a map, which every field will get a bit (automatically) and will create a "calculate changed bits" function (also automatically).
the first bit would be all, so if the state object has more than 30 fields it will still work where needed.

I thought it could be a good idea,
WDYT?
