### PR TITLE
Pass actions into middleware initializers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ export const initStore: Function = (store, ...middlewares) => {
       super()
       self = this
       this.state = store.initialState
-      initializedMiddlewares = middlewares.map(m => m(store, self))
+      initializedMiddlewares = middlewares.map(m => m(store, self, actions))
       this.value = { actions, state: this.state }
     }
 


### PR DESCRIPTION
This was reverted in #20 (accidentally?), causing the devtools integration middleware to break.