### PR TITLE
Improve typings for typescript with generics

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,29 +1,27 @@
-declare module 'react-waterfall' {
+import { ComponentType } from 'react';
 
-  import React from 'react'
-
-  declare type State = any
-  declare type Self = any
-  declare type Action = (state: State) => any
-  declare type Actions = { [key: string]: Action }
-  declare type Subscriber = (action: Action, state: State) => void
-
-  declare type Store = {
-    initialState: State
-    actions: Actions
+export type Action<T> = (...args: any[]) => void
+export type Actions<T> = {
+  [K: string]: Action<T>
+}
+export type Store<T, A> = {
+  initialState: T
+  actions: {
+    [K in keyof A]: (state: T, ...args: any[]) => T | Promise<T>
   }
+}
 
-  declare type Middleware = (store: Store, self: Self) => (action: string) => void
+export type Subscriber<T, A> = (action: keyof A, state: T, ...args: any[]) => void
 
-  declare export const initStore: (
-    state: any,
-    middlewares?: Middleware[],
-  ) => {
-    Provider: React.Component<any>
-    Consumer: React.Component<any>
-    connect: (state: any) => (component: React.Component<any>) => React.Component<any>
-    actions: Actions
-    getState: () => State
-    subscribe: Subscriber
-  }
+export type Middleware<T, A> = (store: Store<T, A>, self: ComponentType<any>) => (action: keyof A, ...args: any[]) => void
+
+export type Connect<T, P = any> = (selector: (state: T) => P) => (baseComponet: ComponentType<any>) => ComponentType<any>
+
+export function initStore<T, A extends Actions<T>>(store: Store<T, A>, ...middlewares: Middleware<T, A>[]): {
+  Provider: ComponentType<any>
+  Consumer: ComponentType<any>
+  connect: Connect<T>
+  actions: A
+  getState: () => T
+  subscribe: (subscruber: Subscriber<T, A>) => void
 }


### PR DESCRIPTION
This way, the store's state type and action type are inferred. This helps with autocomplete in editors.
Here is a sample of how it will be.

```ts
import * as React from 'react';
import { initStore, Store } from './dist';

type State = {
  count: number
}

type Actions = {
  increment: () => void,
  incrementBy: (by: number) => void;
}

const store: Store<State, Actions> = {
  initialState: { count: 0 },
  actions: {
    increment: ({ count }) => ({ count: count + 1 }),
    incrementBy: ({ count }, by: number) => ({ count: count + by })
  },
}

const { Provider, connect } = initStore(store)

type CountProps = { count?: number, actions?: Actions };
let Count: React.ComponentType<CountProps> = ({ count, actions }) => (
  <div>
    {count}
    <button onClick={actions.increment}>+</button>
    <button onClick={() => actions.incrementBy(3)}>+3</button>
  </div>
)

Count = connect(state => ({ count: state.count }))(Count)

const App = () => (
  <Provider>
    <Count />
  </Provider>
)

```

Type of the `connect` function can be improved though to accept incoming props and merge with props from selector function.
