### PR TITLE
Fixing non-mapped props don't trigger re-render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,9 +48,9 @@ export const initStore: Function = (store, ...middlewares) => {
     _children = () => this.props.children
 
     prevent = ({ state, actions }) => {
-      const { mapStateToProps } = this.props
+      const { mapStateToProps, children /* exclude children from rest */, ...rest } = this.props
       return (
-        <Prevent {...mapStateToProps(state)} actions={actions} _children={this._children} />
+        <Prevent {...mapStateToProps(state)} {...rest} actions={actions} _children={this._children} />
       )
     }
 
@@ -64,9 +64,9 @@ export const initStore: Function = (store, ...middlewares) => {
   }
 
   const connect = mapStateToProps => WrappedComponent => {
-    const ConnectComponent = (props) =>
-      <Consumer mapStateToProps={mapStateToProps}>
-        {injectedProps => <WrappedComponent {...props} {...injectedProps} />}
+    const ConnectComponent = props =>
+      <Consumer mapStateToProps={mapStateToProps} {...props}>
+        {injectedProps => <WrappedComponent {...injectedProps} />}
       </Consumer>
     ConnectComponent.displayName = `Connect(${WrappedComponent.displayName || WrappedComponent.name || 'Unknown'})`
     return ConnectComponent


### PR DESCRIPTION
Fixing non-mapped props don't trigger re-render because not passed through `Prevent`.

The connected component own props are not passed thorugh the prevent component, causing non-mapped props not to cause re-render.

Example:
```js
//pseudo
const Com = ({ value, valueFromState }) => <div><h1>{value}</h1>{valueFromState}</div>;
const CnctCom = connect(state => ({valueFromState: state.valueFromState}), Com);

class HOC extends Component {
  ...
  render() {
    return <CnctCom value={this.state.value} >
  }
}
//changing this.state.value in HOC will not trigger a re-render in Com.
```