### PR TITLE
Avoid needing to return full state (TS)

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -7,7 +7,7 @@ export type Actions<T> = {
 export type Store<T, A> = {
   initialState: T
   actions: {
-    [K in keyof A]: (state: T, ...args: any[]) => T | Promise<T>
+    [K in keyof A]: (state: T, ...args: any[]) => Partial<T> | Promise<Partial<T>>
   }
 }
 


### PR DESCRIPTION
As we do not need to return the full state we should reflect this in TypeScript. Otherwise, we will get into trouble and need to use the spread operator a couple of times.

Simple example:

```ts
export interface AppState {
  count: number;
  loggedIn: boolean;
}

export interface AppActions {
  increment(): void;
}

const store: Store<AppState, AppActions> = {
  initialState: {
    count: 0,
    loggedIn: false,
  },
  actions: {
    increment: ({ count }) => ({
      count: count + 1,
    }),
  },
};
```

With the typings as of now TS will complain and we would be forced to do the following (or something similar).

```ts
const store: Store<AppState, AppActions> = {
  initialState: {
    count: 0,
    loggedIn: false,
  },
  actions: {
    increment: ({ count, ...rest }) => ({
      ...rest,
      count: count + 1,
    }),
  },
};
```

As we now this is unnecessary... therefore with the improved typings the upper version stays correct - and TS recognizes this.