### PR TITLE
Fix issue with consecutive updates, removing the option to return a promise in action creators

### DIFF
--- a/src/__test__/__snapshots__/index.test.js.snap
+++ b/src/__test__/__snapshots__/index.test.js.snap
@@ -4,7 +4,7 @@ exports[`actions triggered and state updated 1`] = `"0"`;
 
 exports[`actions triggered and state updated 2`] = `"1"`;
 
-exports[`consecutive actions update state accordingly 1`] = `"1"`;
+exports[`consecutive actions update state accordingly 1`] = `"2"`;
 
 exports[`render provider with its children 1`] = `
 <h1>

--- a/src/__test__/__snapshots__/index.test.js.snap
+++ b/src/__test__/__snapshots__/index.test.js.snap
@@ -4,6 +4,8 @@ exports[`actions triggered and state updated 1`] = `"0"`;
 
 exports[`actions triggered and state updated 2`] = `"1"`;
 
+exports[`consecutive actions update state accordingly 1`] = `"1"`;
+
 exports[`render provider with its children 1`] = `
 <h1>
   Children

--- a/src/__test__/index.test.js
+++ b/src/__test__/index.test.js
@@ -61,3 +61,26 @@ test('actions triggered and state updated', () => {
   actions.increment()
   expect(tree.toJSON()).toMatchSnapshot()
 })
+
+test('consecutive actions update state accordingly', () => {
+  const { Provider, connect, actions } = store
+
+  class PlusTwoOnMountCount extends React.Component {
+    componentDidMount() {
+      actions.increment()
+      actions.increment()
+    }
+    render() {
+      return this.props.count;
+    }
+  }
+  const Count = connect(({ count }) => ({ count }))(PlusTwoOnMountCount)
+
+  const App = () => (
+    <Provider>
+      <Count />
+    </Provider>
+  )
+  const tree = renderer.create(<App />)
+  expect(tree.toJSON()).toMatchSnapshot()
+})


### PR DESCRIPTION
I Fixed the issue with consecutive action calls

I **removed** the option to return a `Promise` from action creators.
This seems unnecessary because you could now always run the action and it will apply on the current state, so running it from a promise created in the code (not in the store actions) would work the same.

I also added a unit test for it (which failed on the version before my change, see first commit).

**Point of thought**: Shouldn't we use the middleware as a pipeline to interfere with the action creators, passing them the functional setState and let the middleware decide if and when to pass it to the next middleware (allowing thunks/promise middlewares like in redux). 