### PR TITLE
Small refactor for IE 10 compatibility (yes, really)

### DIFF
--- a/src/Components/Provider.js
+++ b/src/Components/Provider.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-disable no-undef */
 
-import React, { Component } from 'react'
+import React from 'react'
 
 import type { CreateProvider, State } from '../types'
 
@@ -12,7 +12,7 @@ const EnhancedProvider: CreateProvider = (
   Provider,
   initialState,
 ) =>
-  class EnhancedProvider extends Component<Props, State> {
+  class EnhancedProvider extends React.Component<Props, State> {
     constructor(props) {
       super()
       this.state = props.initialState || initialState


### PR DESCRIPTION
Hi there, 
I've been using latest 4.0.0-4 version of your package and it's great! But I found IE9 and IE10 do not play well with "import React, { Component } from 'react'" and are only happy when Component is not destructured, and is used in extends like "React.Component" 

Hope you don't mind.