### PR TITLE
Watchman configuration

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,9 @@
+{
+  "ignore_dirs": [
+    ".git",
+    "node_modules",
+    "src",
+    "examples",
+    ".circleci"
+  ]
+}


### PR DESCRIPTION
I hope this is okay to propose. I use Watchman and `wml` rather than `npm link` because `npm link` doesn't work well with React Native and Expo. So this config file tells Watchman which folders to ignore when copying the contents of the repo as if it had been installed by npm.