### PR TITLE
Make sure to pass props to base class constructor

### DIFF
--- a/src/Components/Provider.js
+++ b/src/Components/Provider.js
@@ -14,7 +14,7 @@ const EnhancedProvider: CreateProvider = (
 ) =>
   class EnhancedProvider extends Component<Props, State> {
     constructor(props) {
-      super()
+      super(props)
       this.state = props.initialState || initialState
       setProvider(this)
     }


### PR DESCRIPTION
I'm not sure if this is a bug, but the [React docs say](https://reactjs.org/docs/react-component.html#constructor) `you should call super(props) before any other statement`. 

It's probably harmless, but I feel like it's more future-proof to pass it along.