### PR TITLE
Added ownprops to mapStateToProps

### DIFF
--- a/src/__test__/index.test.js
+++ b/src/__test__/index.test.js
@@ -111,3 +111,20 @@ test('async actions', async () => {
   const instance = tree.root.findByType(Stars).children[0]
   expect(typeof instance.props.stars).toBe('number')
 })
+
+test('connect(): allow ownprops from mapStateToProps', async () => {
+  const { Provider, connect, actions } = store
+
+  const Stars = connect(({ stars }, { multiply }) => ({ stars: stars * multiply }))(({ stars }) => stars)
+
+  const App = () => (
+    <Provider>
+      <Stars multiply={2} />
+    </Provider>
+  )
+  const tree = renderer.create(<App />)
+  await actions.getStars()
+
+  const instance = tree.root.findByType(Stars).children[0]
+  expect(instance.props.stars).toBe(20000)
+})

--- a/src/helpers/connect.js
+++ b/src/helpers/connect.js
@@ -11,7 +11,7 @@ const connect: CreateConnect = Consumer => mapStateToProps => WrappedComponent =
   const ConnectedComponent = props => (
     <Consumer>
       {state => {
-        const filteredState = mapStateToProps(state || {})
+        const filteredState = mapStateToProps(state || {}, props)
         return (
           <Prevent
             renderComponent={renderComponent}


### PR DESCRIPTION
In redux I am used to: 

`const mapStateToProps = (state,ownprops) => ...`

Ownprops was missing from `mapStateToProps`, this PR adds it. 